### PR TITLE
fix: winningNumber の初期値修正

### DIFF
--- a/src/hook/useLottery.ts
+++ b/src/hook/useLottery.ts
@@ -10,7 +10,7 @@ interface UseLottery extends UseSetLottery {
 
 const winningNumberState = atom<number>({
   key: "winningNumber",
-  default: 1,
+  default: Math.floor(Math.random() * (151 - 1)) + 1,
 });
 
 export const useLottery = (): UseLottery => {


### PR DESCRIPTION
closed #70 